### PR TITLE
Do `injectContext` before check

### DIFF
--- a/src/main/docker/Dockerfile-frontenvoy
+++ b/src/main/docker/Dockerfile-frontenvoy
@@ -1,5 +1,4 @@
-FROM envoyproxy/envoy:v1.12.0
+FROM dio123/envoy-6520
 
-RUN apt-get update && apt-get -q install -y \
-    curl
+RUN apk add curl --no-cache
 CMD /usr/local/bin/envoy -c /etc/front-envoy.yaml --service-cluster front-proxy


### PR DESCRIPTION
@enbohm If you have time please try with this image, seems like the http implementation of `ext_authz` is missing `injectContext`. This image (`dio123/envoy-6520`) here has it.

![image](https://user-images.githubusercontent.com/73152/68528795-083dd080-032a-11ea-9f91-20c95b7970b9.png)

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>